### PR TITLE
Updated to use stock openapi-generator templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ is a quick-start for building a new OpenAPI driven application in [Quarkus](http
 ```bash
 mvn archetype:generate -DarchetypeGroupId=com.redhat.consulting \
                        -DarchetypeArtifactId=openapi-quarkus-archetype \
-                       -DarchetypeVersion=1.0.3 \
+                       -DarchetypeVersion=1.0.4 \
                        -Dpackage=com.redhat.runtimes \
                        -DgroupId=com.redhat.runtimes.quarkus \
                        -DartifactId=quarkus-petstore \
@@ -39,7 +39,9 @@ mvn archetype:generate -DarchetypeGroupId=com.redhat.consulting \
 
 - Integrates OpenAPI Generator via Maven Plugin
 - Generates JPA Entity classes from the OpenAPI contract
-- Generates API Interfaces with JAX-RS/RestEasy annotations
+  - Uses the OpenAPI Generator configuration option `additionalModelTypeAnnotations` to add `@javax.persistence.Entity` on each Model
+  - Uses `x-extra-annotation` on Model fields to add JPA annotations to getters
+- Generates API Interfaces with JAX-RS annotations
 
 ## Forthcoming Features
 

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -3,18 +3,32 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.attribute.PosixFilePermissions
+import java.util.stream.Collectors
 
 
 String operatingSystem = System.getProperty("os.name").toLowerCase(Locale.ENGLISH)
 
+Path projectPath = Paths.get(request.outputDirectory, request.artifactId)
+
+Path mvnWrapper = Paths.get(projectPath.toString(), "mvnw.cmd")
 
 if (!operatingSystem.contains("windows")) {
-  Path projectPath = Paths.get(request.outputDirectory, request.artifactId)
-
-  Properties properties = request.properties
-
-  Path mvnWrapper = Paths.get(projectPath.toString(), "mvnw")
+  mvnWrapper = Paths.get(projectPath.toString(), "mvnw")
 
   Files.setPosixFilePermissions(mvnWrapper, PosixFilePermissions.fromString("rwxrwxrwx"))
-
 }
+
+def err = new StringBuilder()
+def out = new StringBuilder()
+
+def env = System.getenv().keySet().stream().map({key -> return "${key}=${System.getenv().get(key)}" }).collect(Collectors.toList())
+
+def proc = "${mvnWrapper.toAbsolutePath()} generate-sources".execute(env, projectPath.toAbsolutePath().toFile())
+
+proc.consumeProcessOutput(out, err)
+proc.waitFor()
+println("${out}\n${err}\n")
+
+def openApiGenIgnore = Paths.get(request.outputDirectory, request.artifactId, ".openapi-generator-ignore").toFile()
+
+openApiGenIgnore.append("\n**/*Impl.java")

--- a/src/main/resources/archetype-resources/.openapi-generator-ignore
+++ b/src/main/resources/archetype-resources/.openapi-generator-ignore
@@ -1,7 +1,3 @@
 pom.xml
-**/RestApplication.java
-**/*.xml
 build.gradle
 settings.gradle
-**/*Impl.java
-**/JacksonConfig.java

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -127,16 +127,16 @@
               <goal>generate</goal>
             </goals>
             <configuration>
-              <generatorName>jaxrs-resteasy-eap</generatorName>
+              <generatorName>jaxrs-spec</generatorName>
+              <library>quarkus</library>
               <groupId>${project.groupId}</groupId>
               <artifactId>${project.artifactId}</artifactId>
               <artifactVersion>${project.version}</artifactVersion>
-              <templateDirectory>templates</templateDirectory>
-              <output>./</output>
+              <output>${project.basedir}</output>
               <skipOverwrite>false</skipOverwrite>
               <inputSpec>${openapi_app_contract_uri}</inputSpec>
               <configOptions>
-                <dateLibrary>java8-localdatetime</dateLibrary>
+                <dateLibrary>java8</dateLibrary>
                 <modelPackage>${package}.models</modelPackage>
                 <invokerPackage>${package}</invokerPackage>
                 <apiPackage>${package}.api</apiPackage>
@@ -144,8 +144,11 @@
                 <sortModelPropertiesByRequiredFlag>true</sortModelPropertiesByRequiredFlag>
                 <useTags>true</useTags>
                 <java8>true</java8>
+                <useSwaggerAnnotations>false</useSwaggerAnnotations>
+                <interfaceOnly>true</interfaceOnly>
+                <openApiSpecFileLocation>src/main/resources/openapi.yml</openApiSpecFileLocation>
                 <sourceFolder>src/gen/java</sourceFolder>
-                <generateJbossDeploymentDescriptor>false</generateJbossDeploymentDescriptor>
+                <additionalModelTypeAnnotations>@javax.persistence.Entity</additionalModelTypeAnnotations>
               </configOptions>
             </configuration>
           </execution>


### PR DESCRIPTION
With the recent addition of the `quarkus` library option to the [OpenAPI Generator JAX-RS Spec](https://openapi-generator.tech/docs/generators/jaxrs-spec/), this update allows this archetype to make use of the default generator settings.