### PR TITLE
Enable orm selection in archetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ is a quick-start for building a new OpenAPI driven application in [Quarkus](http
 ```bash
 mvn archetype:generate -DarchetypeGroupId=com.redhat.consulting \
                        -DarchetypeArtifactId=openapi-quarkus-archetype \
-                       -DarchetypeVersion=1.0.4 \
+                       -DarchetypeVersion=1.0.5 \
                        -Dpackage=com.redhat.runtimes \
                        -DgroupId=com.redhat.runtimes.quarkus \
                        -DartifactId=quarkus-petstore \

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archetype-descriptor xsi:schemaLocation="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0 http://maven.apache.org/xsd/archetype-descriptor-1.1.0.xsd" name="openapi-quarkus"
-    xmlns="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<archetype-descriptor xsi:schemaLocation="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0 http://maven.apache.org/xsd/archetype-descriptor-1.1.0.xsd
+https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0 " name="openapi-quarkus"
+                      xmlns="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <requiredProperties>
-    <requiredProperty key="openapi_app_contract_uri"></requiredProperty>
+    <requiredProperty key="quarkus_orm_selection">
+      <validationRegex><![CDATA[^(hibernate-orm|hibernate-reactive)$]]></validationRegex>
+    </requiredProperty>
+    <requiredProperty key="openapi_app_contract_uri"/>
   </requiredProperties>
   <fileSets>
     <fileSet filtered="true" encoding="UTF-8">

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -155,6 +155,26 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>net.revelc.code.formatter</groupId>
+        <artifactId>formatter-maven-plugin</artifactId>
+        <version>2.16.0</version>
+        <executions>
+          <execution>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>format</goal>
+            </goals>
+            <configuration>
+              <directories>
+                <directory>${project.basedir}/src/gen/java</directory>
+                <directory>${project.build.sourceDirectory}</directory>
+                <directory>${project.build.testSourceDirectory}</directory>
+              </directories>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.platform.version}</version>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -32,7 +32,7 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-hibernate-reactive-panache</artifactId>
+      <artifactId>quarkus-${quarkus_orm_selection}-panache</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -135,6 +135,7 @@
               <output>${project.basedir}</output>
               <skipOverwrite>false</skipOverwrite>
               <inputSpec>${openapi_app_contract_uri}</inputSpec>
+              <templateDirectory>${project.basedir}/templates</templateDirectory>
               <configOptions>
                 <dateLibrary>java8</dateLibrary>
                 <modelPackage>${package}.models</modelPackage>
@@ -148,7 +149,6 @@
                 <interfaceOnly>true</interfaceOnly>
                 <openApiSpecFileLocation>src/main/resources/openapi.yml</openApiSpecFileLocation>
                 <sourceFolder>src/gen/java</sourceFolder>
-                <additionalModelTypeAnnotations>@javax.persistence.Entity</additionalModelTypeAnnotations>
               </configOptions>
             </configuration>
           </execution>

--- a/src/test/resources/projects/basic/archetype.properties
+++ b/src/test/resources/projects/basic/archetype.properties
@@ -4,3 +4,4 @@ groupId=archetype.it
 artifactId=basic
 version=0.1-SNAPSHOT
 openapi_app_contract_uri=https://studio-ws.apicur.io/sharing/fb9d632f-6777-44c6-a22e-0a33d88a1d52?content=true
+quarkus_orm_selection=hibernate-reactive


### PR DESCRIPTION
This PR adds 1 new capability and 1 enhancement

1. New Feature - Select between Hibernate ORM w/ Panache or Hibernate Reactive w/ Panache
    * `-Dquarkus_orm_selection=hibernate-orm`
    * `-Dquarkus_orm_selection=hibernate-reactive`
2. Change out the code generator from JAXRS/Resteasy to JAXRS-Spec/Quarkus and use custom POJO template